### PR TITLE
Allow sourcing from local `queries/` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ m.queries = {
 m.queries.typescript = m.queries.javascript
 ```
 
+The `m.queries` table above can be used to define language-specific highlighting rules via custom Treesitter queries. Alternatively, markid can also source queries from standalone files located in your local runtime `queries/` directory. Simply create a new directory in your nvim config folder for your language of choice, e.g. `$HOME/.config/nvim/queries/python`, and write your query in a file called `markid.scm`
+
 ## Custom Highlight Groups
 
 For more control, you can define the highlight groups `markid1`, `markid2`, ..., `markid10`, this is especially useful for theme designers.

--- a/lua/markid.lua
+++ b/lua/markid.lua
@@ -45,7 +45,10 @@ function M.init()
             attach = function(bufnr, lang)
                 local config = configs.get_module("markid")
 
-                local query = vim.treesitter.parse_query(lang, config.queries[lang] or config.queries["default"])
+                local query = vim.treesitter.get_query(lang, 'markid')
+                if query == nil or query == '' then
+                  query = vim.treesitter.parse_query(lang, config.queries[lang] or config.queries["default"])
+                end
                 local parser = parsers.get_parser(bufnr, lang)
                 local tree = parser:parse()[1]
                 local root = tree:root()


### PR DESCRIPTION
Tiny change that attempts to source a `markid.scm` file under `queries/[LANGUAGE]` before falling back to the config table.

I added this mostly because I've created a few custom queries for this plugin that take up a good chunk of real estate in my init.lua, and I wanted to separate them out into their own files.

Speaking of, what do you think about creating a `community/queries` folder? I know you'd prefer not to have to maintain language-specific queries yourself, and after spending a good chunk of time doing it for the languages I use and how personally tailored I made them, I feel like having a communal spot for people to upload their own custom queries (perhaps not sourced by default?) might be a good compromise from having to maintain them all yourself, or otherwise rely on others to do the maintenance.

If you think this is a good idea, let me know and I can either add my own to this PR or create a new one.