### PR TITLE
Fix #9

### DIFF
--- a/lua/markid.lua
+++ b/lua/markid.lua
@@ -55,7 +55,7 @@ function M.init()
                 local root = tree:root()
 
                 local highlight_tree = function(root_tree, cap_start, cap_end)
-                    if not vim.api.nvim_buf_is_loaded(0) then
+                    if not vim.api.nvim_buf_is_loaded(bufnr) then
                       return
                     end
                     vim.api.nvim_buf_clear_namespace(bufnr, namespace, cap_start, cap_end)


### PR DESCRIPTION
**Fixes #9**

Check `bufnr` instead of `0`. I'm guessing bufdelete.nvim closes the buffer in a way that the current buffer is already a different buffer from the deleted one, and so the check never runs for the actually closed buffer.

I'm not sure if this change has any adverse effects though, I have been running it for a few days, and I haven't gotten any errors yet.